### PR TITLE
Fix Pylint plugin for Pylint 2.8

### DIFF
--- a/flakehell/plugins/_pylint.py
+++ b/flakehell/plugins/_pylint.py
@@ -5,7 +5,17 @@ from typing import Sequence
 
 # external
 try:
-    from pylint.__pkginfo__ import version
+    try:
+        # for pylint < 2.8
+        from pylint.__pkginfo__ import version
+    except ImportError:
+        try:
+            # for Python >= 3.8
+            from importlib import metadata
+            version = metadata.version('pylint')
+        except ImportError:
+            # for pylint >= 2.8 (maybe removed in 3.0?)
+            from pylint import __version__ as version
     from pylint.lint import Run
     from pylint.reporters import BaseReporter
 except ImportError:


### PR DESCRIPTION
If FlakeHell's pylint plugin fails to import `__pkginfo__.version`, it gives up on pylint completely.
Pylint 2.8 changes `__pkginfo__` quite significantly, and `__pkginfo__.version` has become `__pkginfo__.__version__`.
This fixes the plugin to accommodate for the change.