### PR TITLE
Pin flake8 below 4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requires-python=">=3.5"
 requires=[
     "colorama",
     "entrypoints",
-    "flake8>=3.8.0",
+    "flake8>=3.8.0,<4.0.0",
     "pygments",
     "toml",
     "urllib3",


### PR DESCRIPTION
Current version of flakehell does not work with flake8 above 4.0. Pin down flake8 until flakehell has caught up.

Temporarily fixes #18 .
Can fix #19 if a new release is cut. 

