### PR TITLE
Make flakehell work with flake8 4.0.x

### DIFF
--- a/flakehell/_logic/_discover.py
+++ b/flakehell/_logic/_discover.py
@@ -46,6 +46,26 @@ def get_installed(app) -> Iterator[Dict[str, Any]]:
                 raise ValueError('Invalid code format: {}'.format(code))
             plugins_codes[key].append(code)
 
+    plugins = getattr(app.formatting_plugins, 'plugins')
+    for plugin_name in plugins:
+        if plugin_name != 'pylint':
+            continue
+        key = ('formatting_plugins', plugin_name)
+        plugin = plugins[plugin_name]
+        versions[key[-1]] = plugin._version
+
+        # if codes for plugin specified explicitly in ALIASES, use it
+        codes = ALIASES.get(plugin_name, [])
+        if codes:
+            plugins_codes[key] = list(codes)
+            continue
+
+        # otherwise get codes from plugin entrypoint
+        code = plugin_name
+        if not REX_CODE.match(code):
+            raise ValueError('Invalid code format: {}'.format(code))
+        plugins_codes[key].append(code)
+
     if 'flake8-docstrings' in versions:
         versions['flake8-docstrings'] = versions['flake8-docstrings'].split(',')[0]
 

--- a/flakehell/_logic/_discover.py
+++ b/flakehell/_logic/_discover.py
@@ -16,6 +16,7 @@ ALIASES = {
     'flake8-future-import': ('FI', ),
     'flake8-mock': ('M001', ),
     'flake8-pytest': ('T003', ),
+    'flake8-annotations-complexity': ('TAE002', 'TAE003'),
     'logging-format': ('G', ),
     'pycodestyle': ('W', 'E'),
     'pylint': ('C', 'E', 'F', 'I', 'R', 'W'),

--- a/flakehell/_logic/_extractors.py
+++ b/flakehell/_logic/_extractors.py
@@ -221,9 +221,13 @@ def extract_flake8_pytest_style() -> Dict[str, str]:
 
 
 def extract_flake8_annotations_complexity() -> Dict[str, str]:
-    _error_message_template = "TAE002 too complex annotation ({0} > {1})"
-    code, message = _error_message_template.split(' ', maxsplit=1)
-    return {code: message}
+    _error_message_templates = ['TAE002 too complex annotation ({0} > {1})',
+                                'TAE003 too long annotation ({0} > {1})']
+    codes = dict()
+    for _error_message_template in _error_message_templates:
+        code, message = _error_message_template.split(' ', maxsplit=1)
+        codes[code] = message
+    return codes
 
 
 def extract_flake8_future_import() -> Dict[str, str]:

--- a/flakehell/_logic/_extractors.py
+++ b/flakehell/_logic/_extractors.py
@@ -220,9 +220,8 @@ def extract_flake8_pytest_style() -> Dict[str, str]:
 
 
 def extract_flake8_annotations_complexity() -> Dict[str, str]:
-    from flake8_annotations_complexity.checker import AnnotationsComplexityChecker
-
-    code, message = AnnotationsComplexityChecker._error_message_template.split(' ', maxsplit=1)
+    _error_message_template = "TAE002 too complex annotation ({0} > {1})"
+    code, message = _error_message_template.split(' ', maxsplit=1)
     return {code: message}
 
 

--- a/flakehell/_patched/_app.py
+++ b/flakehell/_patched/_app.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 # external
 from flake8.main.application import Application
-from flake8.options.config import MergedConfigParser, get_local_plugins
+from flake8.options.config import ConfigParser, get_local_plugins
 from flake8.plugins.manager import ReportFormatters
 from flake8.utils import parse_unified_diff
 
@@ -111,12 +111,13 @@ class FlakeHellApplication(Application):
 
         # Parse CLI options and legacy flake8 configs.
         # Based on `aggregate_options`.
-        config_parser = MergedConfigParser(
+        config_parser = ConfigParser(
             option_manager=self.option_manager,
             config_finder=config_finder,
         )
         parsed_config = config_parser.parse()
         config.extended_default_select = self.option_manager.extended_default_select.copy()
+        config.extended_default_ignore = self.option_manager.extended_default_ignore.copy()
         for config_name, value in parsed_config.items():
             dest_name = config_name
             # If the config name is somehow different from the destination name,

--- a/tests/test_patched/test_checkers.py
+++ b/tests/test_patched/test_checkers.py
@@ -48,4 +48,4 @@ def test_catches_exception_on_invalid_syntax(tmp_path):
     fchecker.run_checks()
     assert len(fchecker.results) == 1
     assert fchecker.results[0].error_code == 'E999'
-    assert fchecker.results[0].text == 'SyntaxError: invalid syntax'
+    assert fchecker.results[0].text == 'SyntaxError: invalid syntax. Perhaps you forgot a comma?'


### PR DESCRIPTION
EDIT 2: Although this PR works in most cases, I have since discovered that it breaks the `flakehell plugins` call. As there was no feedback on this PR from the maintainer since it was raised and no response to [this issue](https://github.com/flakehell/flakehell/issues/25), I made a PR in another fork that has a [better governance structure](https://github.com/flakeheaven/flakeheaven/discussions/1). It was merged and released on PyPI and hence that fork (flakeheaven 0.11.0) already has 4.0.x support: https://pypi.org/project/flakeheaven/

EDIT: all tests now pass

Until this PR is merged, you can use it by replacing the `flakehell` dependency with `flakeheaven`. For example if you use tox, it could have a section like:

```
[testenv:lint]
wheel_build_env = py38
deps =
    flakeheaven
    flake8
    flake8-isort
    flake8-black
commands =
    flakeheaven lint src tests

```